### PR TITLE
chore: Add support for rector 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",
         "phpstan/phpstan": "^1.10",
-        "rector/rector": "^0.18.8"
+        "rector/rector": "^1.2.0 | ^2.0"
     },
     "homepage": "https://www.invenso.nl",
     "authors": [

--- a/src/Set/ApiPlatformSetList.php
+++ b/src/Set/ApiPlatformSetList.php
@@ -16,12 +16,10 @@ declare (strict_types=1);
 
 namespace Invenso\Rector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
 /**
  * @api
  */
-final class ApiPlatformSetList implements SetListInterface
+final class ApiPlatformSetList
 {
     /**
      * @var string


### PR DESCRIPTION
`SetListInterface` was [marked as deprecated](https://github.com/rectorphp/rector/releases/tag/1.2.1) in `rector` 1.2.1 and [phased out](https://github.com/rectorphp/rector/releases/tag/2.0.4) completely in 2.0.4